### PR TITLE
Raw Feature Vector Option

### DIFF
--- a/documentation/outline.org
+++ b/documentation/outline.org
@@ -29,64 +29,64 @@
 
 ** Methodology
 *** Data Collection via Web Scraping
-- Techniques used:
-  - Python tools: requests, BeautifulSoup, Selenium
-- Ethical and practical considerations
+    - Techniques used:
+      - Python tools: requests, BeautifulSoup, Selenium
+    - Ethical and practical considerations
 
 *** Feature Engineering
-- Processing JSON match data into normalized PyTorch tensors
-- Feature selection criteria
+    - Processing JSON match data into normalized PyTorch tensors
+    - Feature selection criteria
 
 *** PPO Model & Training Procedure
-- Overview of PPO algorithm
-- Network architecture and hyperparameters
-- Training details (epochs, batch size, device)
+    - Overview of PPO algorithm
+    - Network architecture and hyperparameters
+    - Training details (epochs, batch size, device)
 
 *** Action Space Definitions
-- Simple discrete action space: [Abstain, Bet A, Bet B]
-- Extended action space with betting percentages: [0%, 5%, 10%, 25%, 50%, 100%]
+    - Simple discrete action space: [Abstain, Bet A, Bet B]
+    - Extended action space with betting percentages: [0%, 5%, 10%, 25%, 50%, 100%]
 
 *** Reward Function Exploration
-- Binary correctness: +1 correct, -1 incorrect
-- Expected Value (EV)-based reward calculation
-- Kelly criterion-based reward optimization
+  - Binary correctness: +1 correct, -1 incorrect
+  - Expected Value (EV)-based reward calculation
+  - Kelly criterion-based reward optimization
 
 ** Experiments and Results
 *** Experiment 1: Action Space Complexity
-- Performance comparison (accuracy, cumulative return)
-- Analysis of volatility and robustness
+    - Performance comparison (accuracy, cumulative return)
+    - Analysis of volatility and robustness
 
 *** Experiment 2: Reward Functions
-- Comparison between correctness, EV, and Kelly rewards
-- Impact on betting accuracy, returns, and agent learning behaviors
+    - Comparison between correctness, EV, and Kelly rewards
+    - Impact on betting accuracy, returns, and agent learning behaviors
 
 *** Metrics for Evaluation
-- Betting accuracy (% correct)
-- Cumulative returns
-- Sharpe ratio (profitability relative to risk)
+    - Betting accuracy (% correct)
+    - Cumulative returns
+    - Sharpe ratio (profitability relative to risk)
 
 ** Discussion
-- Interpretation of experimental results
-  - Optimal action space and reward function insights
-  - Limitations of PPO in betting scenarios
-- Implications for real-world esports betting
-- Ethical considerations in gambling applications
+  - Interpretation of experimental results
+    - Optimal action space and reward function insights
+    - Limitations of PPO in betting scenarios
+  - Implications for real-world esports betting
+  - Ethical considerations in gambling applications
 
 ** Conclusion
-- Summary of key insights and findings
-- Contributions of the PPO-based approach
-- Recommendations for future research directions
+  - Summary of key insights and findings
+  - Contributions of the PPO-based approach
+  - Recommendations for future research directions
 
 ** References
-- Schulman et al. (2017). [[https://arxiv.org/abs/1707.06347][Proximal Policy Optimization Algorithms]]
-- Sutton & Barto (2018). Reinforcement Learning: An Introduction.
-- Kelly, J. (1956). "A New Interpretation of Information Rate".
-- Thorp, E. O. (1969). "Optimal Gambling Systems for Favorable Games".
+  - Schulman et al. (2017). [[https://arxiv.org/abs/1707.06347][Proximal Policy Optimization Algorithms]]
+  - Sutton & Barto (2018). Reinforcement Learning: An Introduction.
+  - Kelly, J. (1956). "A New Interpretation of Information Rate".
+  - Thorp, E. O. (1969). "Optimal Gambling Systems for Favorable Games".
 
 ** Appendix (optional)
-- Example scraped data
-- Hyperparameter settings
-- Additional experimental graphs
+  - Example scraped data
+  - Hyperparameter settings
+  - Additional experimental graphs
 
 \lstdefinelanguage{json}{
 {
@@ -123,12 +123,11 @@
 
 PPO is a policy gradient reinforcement learning algorithm. PPO is inteneded to optimize the policy performance while maintaining training stability. This algorithm was developed by researchers at Open AI, introduced in 2017 by Schulman et al. as a simpler alternative to Trust Region Policy Optimization (TRPO). Unlike TRPO, which relied on complex second-order optimization, PPO uses a clipped surrogate objective that restricts policy updates to stay within a safe range. The clipping mechanism helps stabilize learning by preventing excessive policy shifts, which risk training stability. PPO is favored for its ease of implementation and sample efficiency. PPO is also noted for strong empirical performance across continuous and discrete action space.
 
-   Our project employs PPO to train a betting agent that makes decisions based on game features described above. While using strong market financial signals, we aimed to evaluate perfomance comparing against agents using various reward and action spaces.
+Our project employs PPO to train a betting agent that makes decisions based on game features described above. While using strong market financial signals, we aimed to evaluate perfomance comparing against agents using various reward and action spaces.
 
-\subsection{Model Choice}
-   For our PPO structure, we used a popular model found on \textit{GitHub} developed by Nikhil Barhate []. In their implementation, the actor-critic use a shared network structure. Initial layers of the unified neural network process input states and then split into two separate heads: one for the actor and another for the critic. This allows for both the policy and value function to share common layers, reducing redundancy and computation overhead.
+For our PPO structure, we used a popular model found on \textit{GitHub} developed by Nikhil Barhate []. In their implementation, the actor-critic use a shared network structure. Initial layers of the unified neural network process input states and then split into two separate heads: one for the actor and another for the critic. This allows for both the policy and value function to share common layers, reducing redundancy and computation overhead.
 
-   To guide policy and value function updates, the advantage function is estimated using Monte Carlor returns. For each time step in an episode, the agent computes the cumulative discounted reward based on the full trajectory. This serves as an estimate for how favorable a given state-action pair was compared to the baseline value function. While this method introduces higher variance compared to bootstrapped alternatives like Generalized Advantage Estimation (GAE), this advantage estimation provides a straightforward way to compute advantages from complete episode data. 
+To guide policy and value function updates, the advantage function is estimated using Monte Carlor returns. For each time step in an episode, the agent computes the cumulative discounted reward based on the full trajectory. This serves as an estimate for how favorable a given state-action pair was compared to the baseline value function. While this method introduces higher variance compared to bootstrapped alternatives like Generalized Advantage Estimation (GAE), this advantage estimation provides a straightforward way to compute advantages from complete episode data. 
 
 \subsection{Hyperparameters}
 Learning Rates: 
@@ -143,10 +142,10 @@ Clipping Parameter:
 
 Our project aims to evaluate multiple agent configurations by varying reward functions and action spaces. The choice of reward function plays a critical role in shaping agent behavior, as poorly designed rewards can hinder effective learning. While betting naturally lends itself to a continuous action space, allowing for flexible wager sizes, we constrain the action space to a discrete set of options for training simplicity and stability.
 
-  A basic action space is defined as a discrete space of three actions: abstaining, betting on team A, or betting on team B.
+A basic action space is defined as a discrete space of three actions: abstaining, betting on team A, or betting on team B.
 
-  A complex action space is defined as a discrete space of nine actions: abstaining, betting $\{5, 10, 25, 50\}$ percent of agent's bankroll on either team A or B
+A complex action space is defined as a discrete space of nine actions: abstaining, betting $\{5, 10, 25, 50\}$ percent of agent's bankroll on either team A or B
 
-  With two different reward functions and action spaces, our project compares the perfomance of three different agents using various combinations. These three agents are defined as so: 
+With two different reward functions and action spaces, our project compares the perfomance of three different agents using various combinations. These three agents are defined as so: 
 
 

--- a/q-bet-agent/feature_vector.py
+++ b/q-bet-agent/feature_vector.py
@@ -31,7 +31,9 @@ WINNER = {
 }
 
 
-MAX_ECON = 16000
+# max econ a person can hold is 16,000
+# per 5 players on a team = 80,000
+MAX_ECON = 80000
 
 
 # round time and rounds capped for 95th percentile of data
@@ -108,7 +110,7 @@ def signed_log_norm(x, cap=ROI_CAP):
     return np.sign(x) * np.log1p(np.abs(x)) / (np.log1p(cap) + 1e-6)
 
 
-def append_game_features(d: dict, features: list, ev=False):
+def append_game_features(d: dict, features: list, ev=False) -> None:
     """
     Extracts and encodes features from a single game round dictionary,
     and appends them to the provided feature list.
@@ -191,19 +193,82 @@ def append_game_features(d: dict, features: list, ev=False):
     sa, sb = map(float, d["score"].split("-"))
     features.extend([sa / MAX_ROUNDS, sb / MAX_ROUNDS])
 
-    # two extra features are added if EV is set to true
     # EV of teams
+    ev_a = p_a * (odds_a - 1) - (1 - p_a)
+    ev_b = p_b * (odds_b - 1) - (1 - p_b)
+
     # Kelly Criterion for teams
-    if ev:
-        ev_a = p_a * (odds_a - 1) - (1 - p_a)
-        ev_b = p_b * (odds_b - 1) - (1 - p_b)
-
-        kelly_a = 0.0 if ev_a <= 0 else ev_a / (odds_a - 1)
-        kelly_b = 0.0 if ev_b <= 0 else ev_b / (odds_b - 1)
-        features.extend([ev_a, ev_b, kelly_a, kelly_b])
+    kelly_a = 0.0 if ev_a <= 0 else ev_a / (odds_a - 1)
+    kelly_b = 0.0 if ev_b <= 0 else ev_b / (odds_b - 1)
+    features.extend([ev_a, ev_b, kelly_a, kelly_b])
 
 
-def process_state(json_str: str) -> Optional[List[Tuple[str, int, torch.Tensor]]]:
+def append_raw_features(d: dict, features: list) -> None:
+    """
+    Extracts and encodes features from a single game round dictionary,
+    and appends them to the provided feature list. This function uses raw
+    data and no market signals.
+
+    Handles:
+        - Categorical string values via one-hot encoding.
+        - Numerical values via normalization.
+        - Dictionary-type values (like player stats) via normalization of subfields.
+
+    Parameters:
+        d (dict): A dictionary containing game round data.
+        features (list): A list to which processed numerical features are appended.
+    """
+
+    # pull econ stats for team a and b
+    init_a_econ, buy_a_econ, final_a_econ = (
+        float(d["initial_team_a_econ"]),
+        float(d["buy_team_a_econ"]),
+        float(d["final_team_a_econ"]),
+    )
+    init_b_econ, buy_b_econ, final_b_econ = (
+        float(d["initial_team_b_econ"]),
+        float(d["buy_team_b_econ"]),
+        float(d["final_team_b_econ"]),
+    )
+
+    features.extend(
+        [
+            init_a_econ / MAX_ECON,
+            buy_a_econ / MAX_ECON,
+            final_a_econ / MAX_ECON,
+            init_b_econ / MAX_ECON,
+            buy_b_econ / MAX_ECON,
+            final_b_econ / MAX_ECON,
+        ]
+    )
+
+    # append player kills normalized
+    a_kills, b_kills = d["kills_end"]["team_a"], d["kills_end"]["team_b"]
+    features.extend([a_kills / MAX_PLAYERS, b_kills / MAX_PLAYERS])
+
+    # odds features
+    raw_odds_a = parse_american_odds(d["team_a_odds"])
+    raw_odds_b = parse_american_odds(d["team_b_odds"])
+    raw_odds_a = raw_odds_a if abs(raw_odds_a) > 1e-6 else 1e-6
+    raw_odds_b = raw_odds_b if abs(raw_odds_b) > 1e-6 else 1e-6
+    odds_a, odds_b = am_to_decimal(raw_odds_a), am_to_decimal(raw_odds_b)
+    features.extend([min(odds_a, 10) / 10, min(odds_b, 10) / 10])
+
+    # normalize and append duration
+    clipped_duration = min(float(d["duration"]), MAX_ROUND_TIME)
+    features.append(clipped_duration / MAX_ROUND_TIME)
+
+    # append winner
+    features.extend(ohe(d["winner"], WINNER))
+
+    # cumulative score
+    sa, sb = map(float, d["score"].split("-"))
+    features.extend([sa / MAX_ROUNDS, sb / MAX_ROUNDS])
+
+
+def process_state(
+    json_str: str, raw: bool = False
+) -> Optional[List[Tuple[str, int, torch.Tensor]]]:
     """
     Parses a game state JSON string, extracts round-level features from game1 round_1,
     applies normalization and encoding, and converts the result into a PyTorch tensor.
@@ -234,7 +299,10 @@ def process_state(json_str: str) -> Optional[List[Tuple[str, int, torch.Tensor]]
             for round_idx, (_, value) in enumerate(rounds.items()):
                 feature_vector = []
 
-                append_game_features(value, feature_vector)
+                if raw:
+                    append_raw_features(value, feature_vector)
+                else:
+                    append_game_features(value, feature_vector)
 
                 final_feature_vector = torch.tensor(feature_vector, dtype=torch.float32)
                 feature_states.append(
@@ -242,11 +310,11 @@ def process_state(json_str: str) -> Optional[List[Tuple[str, int, torch.Tensor]]
                 )
 
                 #  or round_idx == len(rounds.items()) - 1
-                # if round_idx == 0:
-                #     print("\nRound:", round_idx + 1)
-                #     print("Cardinality:", len(feature_vector))
-                #     print(" Raw Feature Vector:\n", feature_vector, "\n")
-                #     print(" Final Feature Vector:\n", final_feature_vector, "\n\n")
+                if round_idx == 0:
+                    print("\nRound:", round_idx + 1)
+                    print("Cardinality:", len(feature_vector))
+                    print(" Raw Feature Vector:\n", feature_vector, "\n")
+                    print(" Final Feature Vector:\n", final_feature_vector, "\n\n")
 
         return feature_states
 
@@ -268,12 +336,40 @@ Features Pulled:
  - Odds-ROI A, B (2d)
  - Duration (1d)
  - Winner flag A, B (2d)
+ - Score A, B
+ - EV
+ - Kelly Criterion
 
 --- Game: Intel Extreme Masters Melbourne 2025 ---
 
 
 Round: 1
-Cardinality: 19
+Cardinality: 23
+ Raw Feature Vector:
+ [0.9, 0.41875, np.float64(1.0121845991223732), np.float64(0.7798450741608249), 1.0, 0.4, 0.0075, 0.0203125, 0.16993006993006993, 0.20400000000000001, 0.5455565529622981, 0.4544434470377019, 0.4115226337448559, 0.5098039215686274, 0.4266666666666667, np.float64(1.0), np.float64(0.0), 0.041666666666666664, 0.0] 
+
+ Final Feature Vector:
+ tensor([0.9000, 0.4187, 1.0122, 0.7798, 1.0000, 0.4000, 0.0075, 0.0203, 0.1699,
+        0.2040, 0.5456, 0.4544, 0.4115, 0.5098, 0.4267, 1.0000, 0.0000, 0.0417,
+        0.0000]) 
+
+"""
+"""
+Raw Feature Vector of Cardinality 14 dimensions
+
+Features Pulled:
+ - Raw econ A, B (2d)
+ - Kills A, B (2d)
+ - Decimal odds A, B (2d)
+ - Duration (1d)
+ - Winner flag A, B (2d)
+ - Score A, B
+
+--- Game: Intel Extreme Masters Melbourne 2025 ---
+
+
+Round: 1
+Cardinality: 15
  Raw Feature Vector:
  [0.9, 0.41875, np.float64(1.0121845991223732), np.float64(0.7798450741608249), 1.0, 0.4, 0.0075, 0.0203125, 0.16993006993006993, 0.20400000000000001, 0.5455565529622981, 0.4544434470377019, 0.4115226337448559, 0.5098039215686274, 0.4266666666666667, np.float64(1.0), np.float64(0.0), 0.041666666666666664, 0.0] 
 


### PR DESCRIPTION
`process_state` has boolean choice to use raw data

this will prepend the feature vector differently, using raw init, final, buy econs

it still has calculated odds, duration, players killed, score, and winner

it is still in a tuple format

`MAX_ECON` has also been changed to include the ENTIRE team's max econ